### PR TITLE
dnt script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,11 @@ deno.lock
 .cache
 .trash
 .DS_Store
+
+# output
 out/*
 !out/.gitkeep
+npm/
 
 # conifgs
 .vscode/

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -33,6 +33,7 @@
 	"nodeModulesDir": true,
 	"vendor": false,
 	"tasks": {
+		"clean": "rm -r ./npm ; rm -r ./static/out/*",
 		"testEnvVars": "deno run --allow-read --allow-env --allow-net ./src/tests/vaildate.js"
 	},
 	"test": {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -34,6 +34,7 @@
 	"vendor": false,
 	"tasks": {
 		"clean": "rm -r ./npm ; rm -r ./static/out/*",
+		"npm": "deno run --allow-all ./scripts/build-npm.js",
 		"testEnvVars": "deno run --allow-read --allow-env --allow-net ./src/tests/vaildate.js"
 	},
 	"test": {

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "description": "A Deno library/module for Wordnik's API",
   "main": "./src/index.js",
-	"type": "module",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ArkhamCookie/deno-wordnik.git"
-	},
-	"bugs": {
-			"url": "https://github.com/ArkhamCookie/deno-wordnik/issues"
-	},
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ArkhamCookie/deno-wordnik.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ArkhamCookie/deno-wordnik/issues"
+  },
   "scripts": {
     "http:test": "./src/tests/vaildate.js",
     "clean": "rm -r ./out/*",
@@ -23,7 +23,7 @@
     "eslint": "^8.47.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.28.1",
-    "eslint-plugin-n": "^16.0.1",
+    "eslint-plugin-n": "^16.0.2",
     "eslint-plugin-promise": "^6.1.1",
     "jsdoc": "^4.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wordnik-api-lib",
   "version": "1.0.0",
-  "description": "",
+  "description": "A Deno library/module for Wordnik's API",
   "main": "./src/index.js",
 	"type": "module",
 	"repository": {
@@ -12,7 +12,7 @@
 			"url": "https://github.com/ArkhamCookie/deno-wordnik/issues"
 	},
   "scripts": {
-    "test": "./src/tests/vaildate.js",
+    "http:test": "./src/tests/vaildate.js",
     "clean": "rm -r ./out/*",
     "jsdoc": "npm run clean ; jsdoc ./src --configure ./jsdoc.json --destination ./out/"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "1.0.0",
   "description": "",
   "main": "./src/index.js",
+	"type": "module",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ArkhamCookie/deno-wordnik.git"
+	},
+	"bugs": {
+			"url": "https://github.com/ArkhamCookie/deno-wordnik/issues"
+	},
   "scripts": {
     "test": "./src/tests/vaildate.js",
     "clean": "rm -r ./out/*",

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -1,0 +1,29 @@
+import { build, emptyDir } from 'https://deno.land/x/dnt@0.38.1/mod.ts'
+
+await emptyDir('./npm')
+
+await build({
+	entryPoints: ['./src/mod.js'],
+	outDir: './npm',
+	shims: {
+		deno: true
+	},
+	package: {
+		name: 'deno-wordnik',
+		version: Deno.args[0],
+		description: '',
+		license: 'AGPL-3.0-or-later',
+		repository: {
+			type: 'git',
+			url: 'git+https://github.com/ArkhamCookie/deno-wordnik.git'
+		},
+		bugs: {
+			url: 'https://github.com/ArkhamCookie/deno-wordnik/issues'
+			// 'https://github.com/ArkhamCookie/deno-wordnik/issues/new?assignees=&labels=bug&projects=&template=BUG_REPORT.yaml&title=%5BBUG%5D%3A+'
+		}
+	},
+	postBuild() {
+		Deno.copyFileSync('LICENSE', 'npm/LICENSE')
+		Deno.copyFileSync('src/README.md', 'npm/README.md')
+	}
+})

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -8,6 +8,7 @@ await build({
 	shims: {
 		deno: true
 	},
+	scriptModule: false,
 	packageManager: 'pnpm',
 	importMap: 'deno.jsonc',
 	package: {

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -13,7 +13,7 @@ await build({
 	package: {
 		name: 'deno-wordnik',
 		version: '0.0.0',
-		description: '',
+		description: "A Deno library/module for Wordnik's API",
 		license: 'AGPL-3.0-or-later',
 		repository: {
 			type: 'git',

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -8,6 +8,7 @@ await build({
 	shims: {
 		deno: true
 	},
+	test: false,
 	scriptModule: false,
 	packageManager: 'pnpm',
 	importMap: 'deno.jsonc',

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -8,6 +8,8 @@ await build({
 	shims: {
 		deno: true
 	},
+	packageManager: 'pnpm',
+	importMap: 'deno.jsonc',
 	package: {
 		name: 'deno-wordnik',
 		version: '0.0.0',

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -10,7 +10,7 @@ await build({
 	},
 	package: {
 		name: 'deno-wordnik',
-		version: Deno.args[0],
+		version: '0.0.0',
 		description: '',
 		license: 'AGPL-3.0-or-later',
 		repository: {


### PR DESCRIPTION
- ignores npm pkg output
- Added package.json type, repo, bugs
- Created basic/example build script file
- switched version to '0.0.0' while testing
- added clean task (deno)
- added npm task (deno)
- added pkg manager & import map options
- added package.json description
- Disable dnt's cjs output
- Set build test to false
- Updated package.json
