### PR TITLE
Marked `search` & `reverseDictionary` as covered

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -26,6 +26,6 @@
 | --- | --- | --- |
 | [`/randomWord`](https://developer.wordnik.com/docs#!/words/getRandomWord) | Returns a single random WordObject | [ ] |
 | [`/randomWords`](https://developer.wordnik.com/docs#!/words/getRandomWords) | Returns an array of random WordObjects | [ ] |
-| [`/reverseDictionary`](https://developer.wordnik.com/docs#!/words/reverseDictionary) | Reverse dictionary search | [ ] |
-| [`/search/{query}`](https://developer.wordnik.com/docs#!/words/searchWords) | Searches words | [ ] |
+| [`/reverseDictionary`](https://developer.wordnik.com/docs#!/words/reverseDictionary) | Reverse dictionary search | [x] |
+| [`/search/{query}`](https://developer.wordnik.com/docs#!/words/searchWords) | Searches words | [x] |
 | [`/wordOfTheDay`](https://developer.wordnik.com/docs#!/words/getWordOfTheDay) | Returns a specific WordOfTheDay | [x] |


### PR DESCRIPTION
both are deprecated until v5
I added a warning in case someone tries to use them.